### PR TITLE
Filter PVP actions and unusable SCH class actions

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -25,7 +25,7 @@ async function listJobs() {
 }
 
 async function listJobActions(job) {
-  const endpoint = 'search?indexes=Action,CraftAction&filters=ClassJobTargetID';
+  const endpoint = 'search?indexes=Action,CraftAction&filters=IsPvP=0,ClassJobTargetID';
   const actions = await fetch(`${baseUrl}/${endpoint}=${job.ID}`)
     .then((res) => res.json())
     .then(async (actionsRes) => {
@@ -47,7 +47,7 @@ async function listJobActions(job) {
           .then((res) => res.json())
           .then((json) => json.Results);
 
-        if (job.ClassActionWhitelist) {
+        if (job.ClassActionAllowlist) {
           classJobActions = classJobActions.filter(({ Name }) => job.ClassActionAllowlist.includes(Name));
         }
       }

--- a/lib/api.js
+++ b/lib/api.js
@@ -46,6 +46,10 @@ async function listJobActions(job) {
         classJobActions = await fetch(reqUrl)
           .then((res) => res.json())
           .then((json) => json.Results);
+
+        if (job.ClassActionWhitelist) {
+          classJobActions = classJobActions.filter(({ Name }) => job.ClassActionAllowlist.includes(Name));
+        }
       }
 
       return [...classJobActions, ...filteredActions];

--- a/lib/jobs.js
+++ b/lib/jobs.js
@@ -140,7 +140,8 @@ const JOBS = [
     ClassID: 26,
     Role: 'HEAL',
     Weapon: 'Books',
-    Description: "In an age long past, when mankind flourished under the radiance of arcane mastery, the island of Vylbrand was home to a city-state called Nym. Though the history of that age tells of countless wars waged with earth-shattering incantations, it was the brilliant strategic maneuvering of Nym's scholars that allowed their mundane army of mariners to throw back would-be conquerers time and again. These learned men and women defended the freedom of their tiny nation with their unique command over spell-weaving faeries, utilizing the creatures' magicks to heal the wounded and bolster the strength of their allies."
+    Description: "In an age long past, when mankind flourished under the radiance of arcane mastery, the island of Vylbrand was home to a city-state called Nym. Though the history of that age tells of countless wars waged with earth-shattering incantations, it was the brilliant strategic maneuvering of Nym's scholars that allowed their mundane army of mariners to throw back would-be conquerers time and again. These learned men and women defended the freedom of their tiny nation with their unique command over spell-weaving faeries, utilizing the creatures' magicks to heal the wounded and bolster the strength of their allies.",
+    ClassActionAllowlist: ['Resurrection']
   },
   {
     Name: 'Summoner',


### PR DESCRIPTION
There are two changes here:

### Filter out PVP actions
PVP actions are very different in terms of description and functionality. All of the descriptions I see currently in this app are the PVE versions. In order to be consistent and make sure we don't show PVP actions, I've included `IsPvP=0` as a filter to the search query to XIV API. In the SCH example below, two PVP abilities are filtered out: Focalization and Aura Blast.

Perhaps it makes sense to include PVP abilities in another tab? I'm open to dropping this change, but it can be confusing to see PVE abilities mixed together with PVP. It looked like a bug to me since I'd never played PVP on the job I was using this tool for.

### Remove all but Resurrection from SCH class abilities
Once a Scholar job stone is equipped, Scholars lose all access to Arcanist abilities except for Resurrection. They get their own versions of some of those abilities from the job itself.

This approach is a bit messy, but I believe all approaches to address this would require some sort of deny list or allow list.

### Before
Currently, several actions show up that Scholar doesn't have (like Fester) and some actions show up twice (like Ruin):
<img width="352" alt="Screen Shot 2021-04-06 at 2 17 06 AM" src="https://user-images.githubusercontent.com/9178278/113689473-41918180-967f-11eb-9a58-b4b352dd7509.png">

### After
By removing all the ACN actions besides Resurrection, SCH still has its low level toolkit in place:
<img width="344" alt="Screen Shot 2021-04-06 at 10 19 37 PM" src="https://user-images.githubusercontent.com/9178278/113814541-ac49c800-9726-11eb-8918-868754a42901.png">

Scholar Action Reference: https://na.finalfantasyxiv.com/jobguide/scholar/