### PR TITLE
Only show max level actions by default (with toggle)

### DIFF
--- a/components/ActionPanel/ActionPanel.js
+++ b/components/ActionPanel/ActionPanel.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
+import { useAppState } from 'components/App/context';
+
 import GENERAL_ACTIONS from 'data/GeneralAction.json';
 import MAIN_COMMANDS from 'data/MainCommand.json';
 import MACROS from 'data/MacroIcon.json';
@@ -14,11 +16,16 @@ import Tabs from './Tabs';
 import styles from './ActionPanel.module.scss';
 
 function ActionPanel({ actions, roleActions }) {
+  const { showAllLvl } = useAppState();
   const [activeTab, setActiveTab] = useState('panel-actions');
 
   function handleTabClick(e) {
     const { target } = e.currentTarget.dataset;
     setActiveTab(target);
+  }
+
+  if (!showAllLvl){
+    actions = actions.filter(action => !action.upgradable)
   }
 
   return (

--- a/components/App/context.js
+++ b/components/App/context.js
@@ -35,7 +35,8 @@ function AppContextProvider({
       encodedSlots,
       actions,
       roleActions,
-      showTitles: false
+      showTitles: false,
+      showAllLvl: false,
     }
   );
 

--- a/components/App/reducers.js
+++ b/components/App/reducers.js
@@ -96,6 +96,10 @@ export default function AppReducer(state, payload) {
       return { ...state, showTitles: !state.showTitles };
     }
 
+    case 'toggleAllLvl': {
+      return { ...state, showAllLvl: !state.showAllLvl };
+    }
+
     default: {
       throw new Error(`Unhandled action type: ${payload.type}`);
     }

--- a/components/ControlBar/ControlBar.js
+++ b/components/ControlBar/ControlBar.js
@@ -7,10 +7,14 @@ import styles from './ControlBar.module.scss';
 
 function ControlBar({ jobs, selectedJob }) {
   const appDispatch = useAppDispatch();
-  const { showTitles } = useAppState();
+  const { showTitles, showAllLvl } = useAppState();
 
   function handleTitlesToggle() {
     appDispatch({ type: 'toggleTitles' });
+  }
+
+  function handleMaxLvlToggle() {
+    appDispatch({ type: 'toggleAllLvl' });
   }
 
   const ToggleTitles = () => (
@@ -25,6 +29,18 @@ function ControlBar({ jobs, selectedJob }) {
     </button>
   );
 
+  const ToggleMaxLvl = () => (
+    <button
+      type="button"
+      onClick={() => handleMaxLvlToggle()}
+      data-active={showAllLvl}
+      className={styles.toggleTitlesBtn}
+    >
+      <img src="/images/icon-titles.svg" className="btn-icon" alt="Max Lvl Icon" />
+      All levels
+    </button>
+  );
+
   return (
     <div className={styles.container}>
       <div className={styles.groupLeft}>
@@ -34,6 +50,10 @@ function ControlBar({ jobs, selectedJob }) {
       </div>
 
       <div className={styles.groupRight}>
+        <div className={styles.control}>
+          <ToggleMaxLvl />
+        </div>
+
         <div className={styles.control}>
           <ToggleTitles />
         </div>

--- a/data/UpgradableActions.json
+++ b/data/UpgradableActions.json
@@ -1,0 +1,145 @@
+{
+    "PLD":
+    [
+        "Rage of Halone",
+        "Sheltron",
+        "Spirits Within"
+    ],
+
+    "WAR":
+    [
+        "Inner Beast",
+        "Steel Cyclone",
+        "Berserk",
+        "Raw Intuition"
+    ],
+
+    "DRK":
+    [
+        "Flood of Darkness",
+        "Edge of Darkness"
+    ],
+
+    "GNB":
+    [
+        "Danger Zone",
+        "Heart of Stone"
+    ],
+
+    "WHM":
+    [
+        "Stone",
+        "Aero",
+        "Stone II",
+        "Stone III",
+        "Aero II",
+        "Stone IV",
+        "Glare",
+        "Holy"
+    ],
+
+    "SCH":
+    [
+        "Bio",
+        "Ruin",
+        "Broil",
+        "Bio II",
+        "Broil II",
+        "Broil III",
+        "Art of War"
+    ],
+
+    "AST":
+    [
+        "Combust",
+        "Malefic",
+        "Malefic II",
+        "Combust II",
+        "Malefic III",
+        "Malefic IV",
+        "Gravity"
+    ],
+
+    "SGE":
+    [
+        "Physis",
+        "Dosis",
+        "Dosis II"
+    ],
+
+    "MNK":
+    [
+        "Steel Peak",
+        "Howling Fist",
+        "Arm of the Destroyer",
+        "Flint Strike",
+        "Tornado Kick"
+    ],
+
+    "DRG":
+    [
+        "Jump",
+        "Full Thrust",
+        "Chaos Thrust"
+    ],
+
+    "NIN":
+    [
+        "Assassinate"
+    ],
+
+    "SAM":
+    [
+        "Fuga"
+    ],
+
+    "BRD":
+    [
+        "Venomous Bite",
+        "Windbite",
+        "Straight Shot",
+        "Heavy Shot",
+        "Quick Knock"
+    ],
+
+    "MCH":
+    [
+        "Split Shot",
+        "Slug Shot",
+        "Clean Shot",
+        "Hot Shot",
+        "Rook Autoturret",
+        "Spread Shot"
+    ],
+
+    "BLM":
+    [
+        "Thunder",
+        "Thunder II",
+        "Fire II",
+        "Blizzard II"
+    ],
+
+    "SMN": 
+    [
+        "Ruin", 
+        "Summon Ruby", 
+        "Summon Topaz",
+        "Summon Emerald",
+        "Ruin II",
+        "Aethercharge",
+        "Dreadwyrm Trance",
+        "Outburst",
+        "Summon Ifrit",
+        "Summon Titan",
+        "Summon Garuda"
+    ],
+
+    "RDM":
+    [
+        "Jolt",
+        "Scatter",
+        "Verthunder",
+        "Veraero"
+    ]
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 
+const UPGRADABLE_ACTIONS = require('data/UpgradableActions');
 const { ascByKey } = require('lib/utils');
 const { ADVANCED_JOBS, ROLE_ACTION_IDS } = require('lib/jobs');
 
@@ -56,7 +57,12 @@ async function listJobActions(job) {
         }
       }
 
-      return [...classJobActions, ...filteredActions];
+      // Are actions upgradable (not usable at max level)
+      const upgradableActions = UPGRADABLE_ACTIONS[job.Abbr] ?? [];
+      let actionsWithUpgradedInfo = [...classJobActions, ...filteredActions]
+        .map((action) => ({...action, upgradable: upgradableActions.includes(action.Name)}));
+
+      return actionsWithUpgradedInfo;
     })
     .catch((error) => {
       console.error(error);


### PR DESCRIPTION
This PR makes it so only actions at max level are shown by default.

This will filter "upgradable" actions by default and not show them in the job actions.

Unfortunately, those are hardcoded into the game and not available in the API (or at least the only conversation I found on XIVAPI was this https://discord.com/channels/474518001173921794/474519195963490305/923947076834971648 ).

Added here is a file with the name of all upgradable abilities by job, we use it to add a new key-value pair to actions that enables us to filter the information.

To keep the old functionality, a new toggle as been added to let people show all abilities for all levels. I used the same icon at titles for now cause I suck at graphics.

I tried to keep it in line with the current architecture and to be able to replace is easily if a way to query the API is found.

PS. Thanks for the app, it's really great and it was easy to add this functionality in such a clear codebase.