### PR TITLE
[#151] Fixes issue where Publish button is grayed out

### DIFF
--- a/components/User/context.tsx
+++ b/components/User/context.tsx
@@ -41,8 +41,8 @@ export function UserProvider({ children }: Props) {
   const [state, dispatch] = useReducer(UserReducer as React.Reducer<UserState, UserDispatchActions>, initialState);
 
   useEffect(() => {
-    const layoutsCount = session?.user?._count?.layouts;
-    const canPublish = layoutsCount ? layoutsCount < maxLayouts : false;
+    const layoutsCount = session?.user?._count?.layouts || 0;
+    const canPublish = layoutsCount < maxLayouts;
     dispatch({
       type: UserActions.UPDATE_USER,
       payload: {


### PR DESCRIPTION
The `canPublish` state was being incorrectly set to `false` when users had 0 layouts. This fixes that flag.