### PR TITLE
Profile Page

### DIFF
--- a/components/DetailPanel/DetailPanel.module.scss
+++ b/components/DetailPanel/DetailPanel.module.scss
@@ -36,6 +36,10 @@
     .owner {
       font-size: $font-size-base;
       opacity: 0.75;
+
+      a {
+        color: $color-alt-dark;
+      }
     }
   }
 

--- a/components/DetailPanel/DetailPanel.tsx
+++ b/components/DetailPanel/DetailPanel.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import I18n from 'lib/I18n/locale/en-US';
 import { formatDateString } from 'lib/utils/time';
 import ExportToMacros from 'components/ExportToMacro';
@@ -44,7 +45,11 @@ export default function DetailPanel() {
           <>
             <div className={styles.header}>
               <h3 className="mt-0 mb-0">{title}</h3>
-              <div className={styles.owner}>by {user?.name}</div>
+
+              <div className={styles.owner}>
+                by <Link href={`/user/${userId}`}>{user?.name}</Link>
+              </div>
+
               { updatedAt && (
                 <div className={styles.timestamp}>
                   {I18n.LayoutCard.last_updated}: {formatDateString(updatedAt as string)}

--- a/components/LayoutCard/LayoutCard.module.scss
+++ b/components/LayoutCard/LayoutCard.module.scss
@@ -119,6 +119,14 @@
   .owner {
     font-size: $font-size-base;
     opacity: 0.75;
+
+    a {
+      color: #fff;
+
+      &:hover {
+        color: $color-alt;
+      }
+    }
   }
 
   .timestamp {

--- a/components/LayoutCard/LayoutCard.tsx
+++ b/components/LayoutCard/LayoutCard.tsx
@@ -7,7 +7,6 @@ import Card from 'components/Card';
 import Icon, { Icons } from 'components/Icon';
 import Tags from 'components/Tags';
 import { useUserDispatch, UserActions } from 'components/User';
-import { domain } from 'lib/host';
 import type { ClassJobProps } from 'types/ClassJob';
 import type { ViewDataProps } from 'types/Layout';
 import styles from './LayoutCard.module.scss';

--- a/components/LayoutCard/LayoutCard.tsx
+++ b/components/LayoutCard/LayoutCard.tsx
@@ -7,6 +7,7 @@ import Card from 'components/Card';
 import Icon, { Icons } from 'components/Icon';
 import Tags from 'components/Tags';
 import { useUserDispatch, UserActions } from 'components/User';
+import { domain } from 'lib/host';
 import type { ClassJobProps } from 'types/ClassJob';
 import type { ViewDataProps } from 'types/Layout';
 import styles from './LayoutCard.module.scss';
@@ -46,26 +47,30 @@ export default function LayoutCard(props:Props) {
 
   return (
     <div className={styles.layoutCard}>
-      <Link href={`/job/${layout.jobId}/${layout.id}`}>
-        <Card className={[styles.card, className].join(' ')}>
-          <>
-            <h4>{layout.title}</h4>
+      <Card className={[styles.card, className].join(' ')}>
+        <Link href={`/job/${layout.jobId}/${layout.id}`}>
+          <h4>{layout.title}</h4>
 
-            <p className={styles.description}>{layout.description && layout.description}</p>
+          <p className={styles.description}>
+            {layout.description && layout.description}
+          </p>
+        </Link>
 
-            { !hideName && (
-              <div className={styles.owner}>{layout.user.name}</div>
-            )}
+        { !hideName && (
+          <div className={styles.owner}>
+            <Link href={`/user/${layout.userId}`}>
+              {layout.user.name}
+            </Link>
+          </div>
+        )}
 
-            { layout.updatedAt && (
-              <div className={styles.timestamp}>
-                {I18n.LayoutCard.last_updated}: {formatDateString(layout.updatedAt as string)}
-              </div>
-            )}
-            <Tags layoutView={layout} job={job} />
-          </>
-        </Card>
-      </Link>
+        { layout.updatedAt && (
+          <div className={styles.timestamp}>
+            {I18n.LayoutCard.last_updated}: {formatDateString(layout.updatedAt as string)}
+          </div>
+        )}
+        <Tags layoutView={layout} job={job} />
+      </Card>
 
       { !!isOwner && (
         <div className={styles.cardActions}>

--- a/components/UserNav/UserNav.tsx
+++ b/components/UserNav/UserNav.tsx
@@ -69,11 +69,11 @@ export default function UserNav({ className }:{ className?: string}) {
             <div className={styles.profileImage}>
               <img
                 src={session.user.image}
-                alt={session.user.name || session.user.email}
+                alt={session.user.name}
               />
             </div>
             <div className={styles.title}>
-              {session.user.name || session.user.email}
+              {session.user.name}
             </div>
           </div>
 

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -16,7 +16,17 @@ async function signinUser(session: Session) {
     user = await db.user.create({
       data: {
         name: session.user.name,
-        email: session.user.email
+        email: session.user.email,
+        image: session.user.image
+      }
+    });
+  } else if (session.user.image && !user.image) {
+    user = await db.user.update({
+      where: {
+        id: user.id
+      },
+      data: {
+        image: session.user.image
       }
     });
   }

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -23,8 +23,7 @@ import type { ViewDataProps } from 'types/Layout';
 import styles from './user.module.scss';
 
 interface UserViewProps {
-  user: UserProps,
-  layouts: ViewDataProps[]
+  user: UserProps
 }
 
 export default function User(props:UserViewProps) {
@@ -35,7 +34,7 @@ export default function User(props:UserViewProps) {
   useEffect(() => {
     userDispatch({
       type: UserActions.UPDATE_LAYOUTS,
-      payload: { layouts: props.layouts }
+      payload: { layouts: props.user.layouts }
     });
   }, []);
 
@@ -147,20 +146,20 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const serializedLayouts = user.layouts.map((layout:ViewDataProps) => ({
     ...layout,
     createdAt: layout.createdAt?.toString(),
-    updatedAt: null,
+    updatedAt: layout.updatedAt?.toString(),
     user: { name: user.name }
   }));
 
-  const serializedUser = {
+  const serializedUser:UserProps = {
     name: user.name,
     id: user.id,
-    image: user.image
+    image: user.image,
+    layouts: serializedLayouts
   };
 
   return {
     props: {
-      user: serializedUser,
-      layouts: serializedLayouts
+      user: serializedUser
     }
   };
 };

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import { useEffect } from 'react';
-// import { useSession } from 'next-auth/react';
 import db from 'lib/db';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -16,6 +15,7 @@ import Footer from 'components/Footer';
 import LoadScreen from 'components/LoadScreen';
 import Icon, { Icons } from 'components/Icon';
 import { maxLayouts } from 'lib/user';
+import { domain } from 'lib/host';
 import type { GetServerSideProps } from 'next';
 import type { UserProps } from 'types/User';
 import type { ViewDataProps } from 'types/Layout';
@@ -29,8 +29,8 @@ interface UserViewProps {
 
 export default function User(props:UserViewProps) {
   const userDispatch = useUserDispatch();
-  // const { data: session, status } = useSession({ required: true });
   const { layouts } = useUserState();
+  const canonicalUrl = `${domain}/user/${props.user.id}`;
 
   useEffect(() => {
     userDispatch({
@@ -46,6 +46,7 @@ export default function User(props:UserViewProps) {
       <Head>
         <meta name="robots" content="noindex" />
         <title>{`${props.user.name} Layouts • XIVBARS`}</title>
+        <link rel="canonical" href={canonicalUrl} />
       </Head>
 
       <AppContextProvider>
@@ -108,10 +109,11 @@ export default function User(props:UserViewProps) {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const userId = context?.params?.userId as string;
   const id = parseInt(userId, 10);
+  const userQuery = id ? { id } : { name: userId };
 
-  const user = id ? await db.user.findUnique({
+  const user = await db.user.findFirst({
     where: {
-      id,
+      ...userQuery,
       deletedAt: null
     },
     select: {
@@ -138,7 +140,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         }
       }
     }
-  }) : null;
+  });
 
   if (!user) return { notFound: true };
 

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -26,25 +26,25 @@ interface UserViewProps {
   user: UserProps
 }
 
-export default function User(props:UserViewProps) {
+export default function User({ user }:UserViewProps) {
   const userDispatch = useUserDispatch();
   const { layouts } = useUserState();
-  const canonicalUrl = `${domain}/user/${props.user.id}`;
+  const canonicalUrl = `${domain}/user/${user.id}`;
 
   useEffect(() => {
     userDispatch({
       type: UserActions.UPDATE_LAYOUTS,
-      payload: { layouts: props.user.layouts }
+      payload: { layouts: user.layouts }
     });
   }, []);
 
-  if (!props.user) return null;
+  if (!user) return null;
 
   return (
     <>
       <Head>
         <meta name="robots" content="noindex" />
-        <title>{`${props.user.name} Layouts • XIVBARS`}</title>
+        <title>{`${user.name} Layouts • XIVBARS`}</title>
         <link rel="canonical" href={canonicalUrl} />
       </Head>
 
@@ -56,8 +56,8 @@ export default function User(props:UserViewProps) {
         <div className={styles.hgroup}>
           <h1 className="mt-md">
             <div className={styles.profile}>
-              { props.user.image && <img src={props.user.image} alt="" className={styles.image} /> }
-              {props.user.name}
+              { user.image && <img src={user.image} alt="" className={styles.image} /> }
+              {user.name}
             </div>
           </h1>
           <div className={styles.layoutsCount}>

--- a/pages/user/[userId].tsx
+++ b/pages/user/[userId].tsx
@@ -56,6 +56,7 @@ export default function User(props:UserViewProps) {
         <div className={styles.hgroup}>
           <h1 className="mt-md">
             <div className={styles.profile}>
+              { props.user.image && <img src={props.user.image} alt="" className={styles.image} /> }
               {props.user.name}
             </div>
           </h1>
@@ -116,6 +117,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     select: {
       name: true,
       id: true,
+      image: true,
       layouts: {
         where: {
           deletedAt: null
@@ -138,6 +140,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     }
   }) : null;
 
+  if (!user) return { notFound: true };
+
   const serializedLayouts = user.layouts.map((layout:ViewDataProps) => ({
     ...layout,
     createdAt: layout.createdAt?.toString(),
@@ -147,7 +151,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const serializedUser = {
     name: user.name,
-    id: user.id
+    id: user.id,
+    image: user.image
   };
 
   return {

--- a/pages/user/user.module.scss
+++ b/pages/user/user.module.scss
@@ -26,7 +26,7 @@
 }
 
 .hgroup {
-  align-items: flex-end;
+  align-items: center;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/pages/user/user.module.scss
+++ b/pages/user/user.module.scss
@@ -45,3 +45,16 @@
     margin-left: $spacing-sm;
   }
 }
+
+.profile {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: $spacing-base;
+
+  .image {
+    border-radius: $spacing-sm;
+    height: $spacing-xl-2;
+    width: $spacing-xl-2;
+  }
+}

--- a/prisma/migrations/20240318202036_adds_image_column_to_user/migration.sql
+++ b/prisma/migrations/20240318202036_adds_image_column_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "image" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,6 +14,7 @@ model User {
   id              Int       @id @default(autoincrement())
   name            String?
   email           String    @unique
+  image           String?
   characterId     Int?      @unique
   layouts         Layout[]
   role            Role      @default(USER)

--- a/types/User.d.ts
+++ b/types/User.d.ts
@@ -1,6 +1,10 @@
 import type { ViewDataProps } from 'types/Layout';
 import { UserActions } from 'components/User/actions';
 
+export interface UserProps {
+  name: string
+}
+
 export interface UserState {
   loggedIn: boolean,
   canPublish: boolean,

--- a/types/User.d.ts
+++ b/types/User.d.ts
@@ -2,7 +2,9 @@ import type { ViewDataProps } from 'types/Layout';
 import { UserActions } from 'components/User/actions';
 
 export interface UserProps {
-  name: string
+  name: string,
+  email: string,
+  image: string
 }
 
 export interface UserState {

--- a/types/User.d.ts
+++ b/types/User.d.ts
@@ -3,9 +3,9 @@ import { UserActions } from 'components/User/actions';
 
 export interface UserProps {
   name: string,
-  email: string,
   id: number,
-  image: string
+  image: string,
+  layouts: ViewDataProps[]
 }
 
 export interface UserState {

--- a/types/User.d.ts
+++ b/types/User.d.ts
@@ -4,6 +4,7 @@ import { UserActions } from 'components/User/actions';
 export interface UserProps {
   name: string,
   email: string,
+  id: number,
   image: string
 }
 


### PR DESCRIPTION
* Removes rendering emails as fallback for undefined username. Emails are only used as a unique ids for registering users within the app and there's no need to expose it on the frontend. 
* Adds a public profile view for listing layouts by username
  * Updates the User table to add an `image` column for user profile images
  * Updates authentication process to save the user profile image url for the profile view
  * Link usernames to their profile pages