### PR TITLE
Fixes Layout saving and deletion not working

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@
     "no-debugger": "warn",
     "no-restricted-exports": "off",
     "no-undef": "error",
+    "no-underscore-dangle": "off",
     "no-unused-vars": "warn",
     "prefer-destructuring": "off",
     "react/destructuring-assignment": "off",

--- a/components/LayoutCard/LayoutCard.tsx
+++ b/components/LayoutCard/LayoutCard.tsx
@@ -73,7 +73,6 @@ export default function LayoutCard(props:Props) {
         <div className={styles.footer}>
           <Hearts
             layoutId={layout.id as number}
-            //  eslint-disable-next-line no-underscore-dangle
             count={layout._count?.hearts || 0}
             className={styles.hearts}
           />

--- a/components/SaveForm/SaveForm.tsx
+++ b/components/SaveForm/SaveForm.tsx
@@ -58,7 +58,7 @@ function SaveForm() {
           description: descriptionField.current?.value
         },
         {
-          filterKeys: ['user', 'createdAt', 'deletedAt', 'updatedAt']
+          filterKeys: ['user', 'createdAt', 'deletedAt', 'updatedAt', 'hearted', '_count', 'userId']
         }
       )
     };

--- a/components/User/context.tsx
+++ b/components/User/context.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 import React, {
   createContext, useContext, useReducer, useEffect, ReactNode
 } from 'react';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -120,7 +120,6 @@ export const getServerSideProps: GetServerSideProps = async () => {
       }
     }
   });
-    // eslint-disable-next-line no-underscore-dangle
   const filteredPopularLayouts = popularLayouts.filter((layout:LayoutViewProps) => layout._count.hearts > 0);
 
   return {

--- a/prisma/migrations/20240331225430_adds_referential_action_to_heart_model/migration.sql
+++ b/prisma/migrations/20240331225430_adds_referential_action_to_heart_model/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "Heart" DROP CONSTRAINT "Heart_layoutId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Heart" DROP CONSTRAINT "Heart_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Heart" ADD CONSTRAINT "Heart_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Heart" ADD CONSTRAINT "Heart_layoutId_fkey" FOREIGN KEY ("layoutId") REFERENCES "Layout"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,9 +46,9 @@ model Layout {
 
 model Heart {
   id            Int         @id @default(autoincrement())
-  user          User        @relation(fields: [userId], references: [id])
+  user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId        Int
-  layout        Layout      @relation(fields: [layoutId], references: [id])
+  layout        Layout      @relation(fields: [layoutId], references: [id], onDelete: Cascade)
   layoutId      Int
   createdAt     DateTime    @default(now())
 }

--- a/tests/pages/api/layout.test.ts
+++ b/tests/pages/api/layout.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment node
  */
 
-/* eslint-disable no-underscore-dangle */
 /* eslint-disable import/no-extraneous-dependencies */
 
 import '@testing-library/jest-dom';


### PR DESCRIPTION
The Heart model added a couple of new properties to layout data which prisma complained about because they are not valid when creating, updating, or deleting Layouts