### PR TITLE
Refactoring Action naming convention

### DIFF
--- a/components/SaveForm/SaveForm.tsx
+++ b/components/SaveForm/SaveForm.tsx
@@ -9,6 +9,7 @@ import { userActions } from 'components/User/actions';
 import { appActions } from 'components/App/actions';
 import { systemActions, useSystemDispatch } from 'components/System';
 import analytics from 'lib/analytics';
+import { LAYOUT_FILTER_KEYS } from 'lib/db';
 import type { LayoutViewProps } from 'types/Layout';
 import SignInPrompt from './SignInPrompt';
 
@@ -59,9 +60,7 @@ function SaveForm() {
           description: descriptionField.current?.value,
           published: publishedCheckbox.current?.checked
         },
-        {
-          filterKeys: ['user', 'createdAt', 'deletedAt', 'updatedAt', 'hearted', '_count', 'userId', 'parentLayout']
-        }
+        { filterKeys: LAYOUT_FILTER_KEYS }
       )
     };
 
@@ -84,7 +83,7 @@ function SaveForm() {
           }
         });
 
-        userDispatch({ type: userActions.UPDATE_LAYOUTS, payload: { layouts: layouts.length } });
+        userDispatch({ type: userActions.UPDATE_LAYOUTS, payload: { layouts } });
 
         if (viewAction === 'new') {
           analytics.event({ action: 'form_submit', params: { form_id: 'layout', form_name: 'new_layout' } });

--- a/components/System/actions.ts
+++ b/components/System/actions.ts
@@ -1,8 +1,8 @@
 export const systemActions = {
-  TOGGLE_MODAL: 'toggleModal',
-  SET_MESSAGE: 'setMessage',
-  LOADING_START: 'loadingStart',
-  LOADING_END: 'loadingEnd'
+  TOGGLE_MODAL: 'TOGGLE_MODAL',
+  SET_MESSAGE: 'SET_MESSAGE',
+  LOADING_START: 'LOADING_START',
+  LOADING_END: 'LOADING_END'
 };
 
 export default systemActions;

--- a/components/User/actions.ts
+++ b/components/User/actions.ts
@@ -1,6 +1,6 @@
 export const userActions = {
-  UPDATE_USER: 'UpdateUser',
-  UPDATE_LAYOUTS: 'UpdateLayouts'
+  UPDATE_USER: 'UPDATE_USER',
+  UPDATE_LAYOUTS: 'UPDATE_LAYOUTS'
 };
 
 export default userActions;

--- a/components/User/reducer.ts
+++ b/components/User/reducer.ts
@@ -10,7 +10,7 @@ export function UserReducer(state: UserState, action: UserDispatchActions) {
 
     case userActions.UPDATE_LAYOUTS: {
       const layoutsCount = action.payload?.layouts?.length;
-      const canPublish = layoutsCount ? layoutsCount > maxLayouts : false;
+      const canPublish = layoutsCount !== undefined ? layoutsCount < maxLayouts : false;
       return { ...state, layouts: action.payload.layouts, canPublish };
     }
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,2 @@
+export const SLOT_ID_SEPARATOR = '-';
+export const ROLE_ACTION_PREFIX = 'r';

--- a/lib/db.js
+++ b/lib/db.js
@@ -27,7 +27,7 @@ export function serializeDates(array) {
   }));
 }
 
-const selectLayoutColumns = {
+export const LAYOUT_SELECT = {
   id: true,
   title: true,
   description: true,
@@ -47,9 +47,22 @@ const selectLayoutColumns = {
   }
 };
 
+// Fields that are server-generated or relational and must be stripped before
+// sending layout data to the DB (e.g. in SaveForm).
+export const LAYOUT_FILTER_KEYS = [
+  'user',
+  'createdAt',
+  'deletedAt',
+  'updatedAt',
+  'hearted',
+  '_count',
+  'userId',
+  'parentLayout'
+];
+
 export const layoutsQuery = {
   where: { deletedAt: null },
-  select: selectLayoutColumns,
+  select: LAYOUT_SELECT,
   orderBy: { updatedAt: 'desc' }
 };
 

--- a/lib/utils/slots.ts
+++ b/lib/utils/slots.ts
@@ -2,6 +2,7 @@ import { sortIntoGroups } from 'lib/utils/array.mjs';
 import { defaultState } from 'components/App/defaultState';
 import { layouts, buildHotbars, buildCrossHotbars } from 'lib/xbars';
 import { decorateRouterQuery } from 'lib/utils/url';
+import { SLOT_ID_SEPARATOR, ROLE_ACTION_PREFIX } from 'lib/constants';
 
 import type { LayoutViewProps } from 'types/Layout';
 import type { SlotProps, ActionProps } from 'types/Action';
@@ -112,7 +113,7 @@ function getActionKey({ actionCategory, actions, roleActions }:GetActionKeyProps
     case ACTION_CAT.MainCommand.prefix: return MAIN_COMMAND;
     case ACTION_CAT.MacroIcon.prefix: return MACRO_ICON;
     case ACTION_CAT.PetAction.prefix: return PET_ACTION;
-    case 'r': return roleActions;
+    case ROLE_ACTION_PREFIX: return roleActions;
     default: return actions;
   }
 }
@@ -133,7 +134,7 @@ function setActionsByGroup({
   roleActions
 }:SetActionsByGroupProps) {
   const actionPrefixes = Object.values(ACTION_CAT).map((type) => type.prefix);
-  const prefixes = [...actionPrefixes, 'r'].join('|');
+  const prefixes = [...actionPrefixes, ROLE_ACTION_PREFIX].join('|');
   const actionRegex = new RegExp(prefixes);
   const IDString = actionID.toString();
   const typeMatch = IDString.match(actionRegex);
@@ -231,7 +232,7 @@ export function setActionToSlot({
   roleActions
 }:SetActionToSlotProps) {
   // Parse the slot ID string and build a slot object
-  const [parent, id] = slotID.split('-');
+  const [parent, id] = slotID.split(SLOT_ID_SEPARATOR);
   const slotIdentifier = { parent, id: parseInt(id, 10) - 1 };
   const groupedSlots = slotActions({
     encodedSlots,

--- a/lib/utils/url.ts
+++ b/lib/utils/url.ts
@@ -24,7 +24,7 @@ type hbValue = string|string[]|number[];
 
 export function buildUrl({ viewData, query, mergeData }:BuildURLProps):string {
   const params = { ...viewData, ...query, ...mergeData };
-  const inlcudeKeys = [
+  const includeKeys = [
     'l',
     'hb',
     'isPvp',
@@ -52,7 +52,7 @@ export function buildUrl({ viewData, query, mergeData }:BuildURLProps):string {
     if (key === 'isPvp') return { ...items, [key]: formatPvp(value as string) };
     if (key === 'hb') return { ...items, [key]: value && formatHb(value as hbValue) };
     if (['l', 'layout'].includes(key)) return { ...items, l: value?.toString() };
-    if (inlcudeKeys.includes(key)) return { ...items, [key]: value };
+    if (includeKeys.includes(key)) return { ...items, [key]: value };
     if (key === 'id') return { ...items, parentId: value };
     return items;
   }, {});

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
System and User action values were camelCase/PascalCase; now all five contexts use

  UPPERCASE strings consistently. No dispatch callsites needed touching since they all use the constants.

  canPublish bug (two-part fix)
  - components/User/reducer.ts — comparison was layoutsCount > maxLayouts (always false at normal usage), corrected to layoutsCount < maxLayouts
  - components/SaveForm/SaveForm.tsx — was sending layouts.length (a number) to UPDATE_LAYOUTS; the reducer calls .length on what it receives, so this was returning undefined. Now sends the layouts array

  LAYOUT_SELECT / LAYOUT_FILTER_KEYS — lib/db.js now exports LAYOUT_SELECT (the Prisma select shape, was
  selectLayoutColumns) and a new LAYOUT_FILTER_KEYS array. SaveForm imports LAYOUT_FILTER_KEYS instead of
  repeating the hardcoded list inline

  lib/constants.ts — new file with SLOT_ID_SEPARATOR and ROLE_ACTION_PREFIX; lib/utils/slots.ts uses both
  instead of the bare '-' and 'r' strings

  Typo — inlcudeKeys → includeKeys in lib/utils/url.ts