### PR TITLE
Consolidate Encoding Logic

### DIFF
--- a/components/SaveForm/SaveForm.tsx
+++ b/components/SaveForm/SaveForm.tsx
@@ -9,7 +9,7 @@ import { userActions } from 'components/User/actions';
 import { appActions } from 'components/App/actions';
 import { systemActions, useSystemDispatch } from 'components/System';
 import analytics from 'lib/analytics';
-import { LAYOUT_FILTER_KEYS } from 'lib/db';
+import { LAYOUT_FILTER_KEYS } from 'lib/constants';
 import type { LayoutViewProps } from 'types/Layout';
 import SignInPrompt from './SignInPrompt';
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,2 +1,15 @@
 export const SLOT_ID_SEPARATOR = '-';
 export const ROLE_ACTION_PREFIX = 'r';
+
+// Fields that are server-generated or relational and must be stripped before
+// sending layout data to the DB (e.g. in SaveForm).
+export const LAYOUT_FILTER_KEYS = [
+  'user',
+  'createdAt',
+  'deletedAt',
+  'updatedAt',
+  'hearted',
+  '_count',
+  'userId',
+  'parentLayout'
+];

--- a/lib/db.js
+++ b/lib/db.js
@@ -47,18 +47,6 @@ export const LAYOUT_SELECT = {
   }
 };
 
-// Fields that are server-generated or relational and must be stripped before
-// sending layout data to the DB (e.g. in SaveForm).
-export const LAYOUT_FILTER_KEYS = [
-  'user',
-  'createdAt',
-  'deletedAt',
-  'updatedAt',
-  'hearted',
-  '_count',
-  'userId',
-  'parentLayout'
-];
 
 export const layoutsQuery = {
   where: { deletedAt: null },

--- a/lib/utils/encoding.ts
+++ b/lib/utils/encoding.ts
@@ -1,0 +1,34 @@
+import type { SlotProps } from 'types/Action';
+
+// Canonical URL param name for encoded slot data and its historical aliases
+export const ENCODED_SLOTS_PARAM = 's';
+export const ENCODED_SLOTS_PARAM_ALIASES: string[] = [ENCODED_SLOTS_PARAM, 's1', 'encodedSlots'];
+
+// Resolves the s1/s/encodedSlots URL param aliases to a single value
+export function readSlotParam(query: { s?: string | string[]; s1?: string | string[] }): string | undefined {
+  return (query.s1 || query.s) as string | undefined;
+}
+
+function assignActionIds(slottedActions: SlotProps[]): (string | null)[] {
+  if (!slottedActions) return [];
+  return Object.values(slottedActions).map((slot) => {
+    if (slot.action?.ID) {
+      return (typeof slot.action.Prefix !== 'undefined')
+        ? `${slot.action.Prefix}${slot.action.ID}`
+        : `${slot.action.ID}`;
+    }
+    return '0';
+  });
+}
+
+// Converts a populated slot structure to a comma-separated action ID string
+export function encodeSlots(slots: object): string {
+  const slotActionObject = Object.values(slots);
+  const actionIdGroups = slotActionObject.map((arr) => assignActionIds(arr as SlotProps[]));
+  return actionIdGroups.flat().join(',');
+}
+
+// Parses a comma-separated action ID string to an array of ID strings
+export function decodeSlots(encodedSlots: string): string[] {
+  return encodedSlots.split(',');
+}

--- a/lib/utils/slots.ts
+++ b/lib/utils/slots.ts
@@ -3,6 +3,7 @@ import { defaultState } from 'components/App/defaultState';
 import { layouts, buildHotbars, buildCrossHotbars } from 'lib/xbars';
 import { decorateRouterQuery } from 'lib/utils/url';
 import { SLOT_ID_SEPARATOR, ROLE_ACTION_PREFIX } from 'lib/constants';
+import { encodeSlots, decodeSlots } from 'lib/utils/encoding';
 
 import type { LayoutViewProps } from 'types/Layout';
 import type { SlotProps, ActionProps } from 'types/Action';
@@ -16,26 +17,6 @@ import MAIN_COMMAND from '../../.apiData/MainCommand.json';
 import MACRO_ICON from '../../.apiData/MacroIcon.json';
 import PET_ACTION from '../../.apiData/PetAction.json';
 
-function assignActionIds(slottedActions: SlotProps[]) {
-  if (!slottedActions) return null;
-
-  return Object.values(slottedActions).map((slot) => {
-    if (slot.action?.ID) {
-      return (typeof slot.action.Prefix !== 'undefined')
-        ? `${slot.action.Prefix}${slot.action.ID}`
-        : `${slot.action.ID}`;
-    }
-    return '0';
-  });
-}
-
-function encodeSlots(slots:object):string {
-  const slotActionObject = Object.values(slots);
-  const actionIdGroups = slotActionObject.map((arr) => assignActionIds(arr as SlotProps[]));
-  const actionIds = actionIdGroups.flat();
-  const slotsString = actionIds.join(',');
-  return slotsString;
-}
 
 interface MergeParamsToViewProps {
   params?: ParsedUrlQuery,
@@ -164,7 +145,7 @@ function groupSlotsIntoLayout({
   roleActions
 }:SlotActionsProps) {
   const numSlots = layout?.toString() === '1' ? 12 : 16;
-  const slotRows = sortIntoGroups(encodedSlots?.split(','), numSlots);
+  const slotRows = sortIntoGroups(encodedSlots ? decodeSlots(encodedSlots) : [], numSlots);
   const layoutTemplate = layout === 0 ? buildCrossHotbars() : buildHotbars();
 
   // Take each action group and assign actions to them
@@ -272,9 +253,7 @@ export function setActionsToSlots(props:SetActionsToSlotsProps) {
 }
 
 const modules = {
-  encodeSlots,
   mergeParamsToView,
-  assignActionIds,
   setActionToSlot,
   setActionsToSlots
 };

--- a/lib/utils/url.ts
+++ b/lib/utils/url.ts
@@ -2,6 +2,7 @@ import { domain } from 'lib/host';
 import type { LayoutViewProps, MergeDataProps } from 'types/Layout';
 import { defaultState } from 'components/App/defaultState';
 import { QueryProps } from 'types/Page';
+import { ENCODED_SLOTS_PARAM, ENCODED_SLOTS_PARAM_ALIASES, readSlotParam } from 'lib/utils/encoding';
 
 export function jsonToQuery(json:object) {
   return Object.entries(json)
@@ -48,7 +49,7 @@ export function buildUrl({ viewData, query, mergeData }:BuildURLProps):string {
   }
 
   const decoratedParams = Object.entries(params).reduce((items, [key, value]) => {
-    if (['s', 's1', 'encodedSlots'].includes(key)) return { ...items, s: value };
+    if (ENCODED_SLOTS_PARAM_ALIASES.includes(key)) return { ...items, [ENCODED_SLOTS_PARAM]: value };
     if (key === 'isPvp') return { ...items, [key]: formatPvp(value as string) };
     if (key === 'hb') return { ...items, [key]: value && formatHb(value as hbValue) };
     if (['l', 'layout'].includes(key)) return { ...items, l: value?.toString() };
@@ -71,7 +72,7 @@ export function buildUrl({ viewData, query, mergeData }:BuildURLProps):string {
 }
 
 export function decorateRouterQuery(query:QueryProps) {
-  const encodedSlots = query.s1 || query.s;
+  const encodedSlots = readSlotParam(query);
   // convert isPvp url param to boolean
   const parsePvp = (pvpVal:string):boolean => {
     if (pvpVal === '0') return false;

--- a/pages/job/[jobId]/[layoutId].tsx
+++ b/pages/job/[jobId]/[layoutId].tsx
@@ -126,6 +126,9 @@ export const getServerSideProps:GetServerSideProps = async (context) => {
   const session = await getServerSession(req, res, authOptions);
   const viewerId = session?.user.id;
   const { jobId, layoutId } = context.params as {[key:string]: string};
+  const host = req.headers.host;
+  const protocol = (req.headers['x-forwarded-proto'] as string) || (host?.includes('localhost') ? 'http' : 'https');
+  const baseUrl = `${protocol}://${host}`;
 
   if (layoutId) {
     try {
@@ -139,11 +142,11 @@ export const getServerSideProps:GetServerSideProps = async (context) => {
         body: JSON.stringify({ layoutId, viewerId, method: 'read' }),
         headers: { 'Content-Type': 'application/json' }
       };
-      const fetchView = await fetch(`${domain}/api/layout`, fetchOptions);
+      const fetchView = await fetch(`${baseUrl}/api/layout`, fetchOptions);
       const viewData = await fetchView.json();
 
       // Fetch Job Actions
-      const actionsRequest = await fetch(`${domain}/api/actions?job=${jobId}&isPvp=${viewData.isPvp}`);
+      const actionsRequest = await fetch(`${baseUrl}/api/actions?job=${jobId}&isPvp=${viewData.isPvp}`);
       const { actions, roleActions } = await actionsRequest.json();
 
       // DB List Query Options

--- a/pages/job/[jobId]/new.tsx
+++ b/pages/job/[jobId]/new.tsx
@@ -112,6 +112,9 @@ export const getServerSideProps:GetServerSideProps = async (context) => {
   let parentLayout = null;
 
   const parentIdNumber = parentId ? parseInt(parentId, 10) : null;
+  const host = context.req.headers.host;
+  const protocol = (context.req.headers['x-forwarded-proto'] as string) || (host?.includes('localhost') ? 'http' : 'https');
+  const baseUrl = `${protocol}://${host}`;
 
   if (parentId) {
     const fetchOptions = {
@@ -120,7 +123,7 @@ export const getServerSideProps:GetServerSideProps = async (context) => {
       headers: { 'Content-Type': 'application/json' }
     };
 
-    parentLayout = await fetch(`${domain}/api/layout`, fetchOptions);
+    parentLayout = await fetch(`${baseUrl}/api/layout`, fetchOptions);
     parentLayout = await parentLayout.json();
   }
 
@@ -128,7 +131,7 @@ export const getServerSideProps:GetServerSideProps = async (context) => {
   const selectedJob = jobId ? Jobs.find((job:ClassJobProps) => job.Abbr === jobId) : null;
   if (!selectedJob) return { notFound: true };
 
-  const actionsRequest = await fetch(`${domain}/api/actions?job=${jobId}&isPvp=${pvp}`);
+  const actionsRequest = await fetch(`${baseUrl}/api/actions?job=${jobId}&isPvp=${pvp}`);
   const { actions, roleActions } = await actionsRequest.json();
 
   try {


### PR DESCRIPTION
New file: lib/utils/encoding.ts — single home for the slot serialization format:

  - encodeSlots — converts a slot structure to the comma-separated action ID string (moved from slots.ts)
  - decodeSlots — parses that string back to an array (extracted from the inline split(','))
  - ENCODED_SLOTS_PARAM = 's' — the canonical URL param key
  - ENCODED_SLOTS_PARAM_ALIASES — ['s', 's1', 'encodedSlots'] — the historical aliases that need normalizing
  - readSlotParam — resolves s1 || s to a single value (extracted from inline in url.ts)

  lib/utils/slots.ts — removed encodeSlots and assignActionIds (implementation details of encoding), imports
  them from encoding.ts. Uses decodeSlots() instead of bare .split(',').

  lib/utils/url.ts — replaced the inline string arrays and query.s1 || query.s with the named constants and
  readSlotParam. Now if the URL format ever changes (new alias, different separator, base64, etc.) there's one
  file to edit.