### PR TITLE
Potential fix for code scanning alert no. 13: Server-side request forgery

### DIFF
--- a/pages/job/[jobId]/new.tsx
+++ b/pages/job/[jobId]/new.tsx
@@ -112,9 +112,7 @@ export const getServerSideProps:GetServerSideProps = async (context) => {
   let parentLayout = null;
 
   const parentIdNumber = parentId ? parseInt(parentId, 10) : null;
-  const host = context.req.headers.host;
-  const protocol = (context.req.headers['x-forwarded-proto'] as string) || (host?.includes('localhost') ? 'http' : 'https');
-  const baseUrl = `${protocol}://${host}`;
+  const baseUrl = /^https?:\/\//.test(domain) ? domain : `https://${domain}`;
 
   if (parentId) {
     const fetchOptions = {


### PR DESCRIPTION
Potential fix for [https://github.com/bdejesus/xiv-bars/security/code-scanning/13](https://github.com/bdejesus/xiv-bars/security/code-scanning/13)

Use a trusted, server-controlled base origin instead of `host` / `x-forwarded-proto` from incoming headers. In this file, `domain` is already imported from `lib/host`, so the best minimal fix is:

- Remove dynamic `host`/`protocol` derivation.
- Set `baseUrl` from `domain` only, normalizing to an absolute URL (`https://...` if needed).
- Keep existing functionality (same API endpoints and query behavior) unchanged.

This should be done in `pages/job/[jobId]/new.tsx` at the block around lines 115–117.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
